### PR TITLE
do not use React.FC

### DIFF
--- a/src/templates/typescript/styledReactArrowComponent.ts
+++ b/src/templates/typescript/styledReactArrowComponent.ts
@@ -3,7 +3,7 @@ export default (componentName: string, styleName: string) => (
 
 ${ styleName === 'styles' ? `import { Container } from './${ styleName }';` : `import './${ styleName }';` }
 
-const ${ componentName }: React.FC = () => {
+const ${ componentName } = () => {
   return (
     ${ styleName === 'styles' ? `<Container>` : `<>` }
       <h1>${ componentName }</h1>


### PR DESCRIPTION
reasons: React.FC is typing the function and not the props, https://github.com/facebook/create-react-app/pull/8177.